### PR TITLE
Add message namespace from env to properties

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,8 @@ npm i appinsights-logger --save
 ### Environment setup
 Just set ENV variable `APPINSIGHTS_INSTRUMENTATIONKEY`
 
+Set the AI_MESSAGE_NAMESPACE ENV variable to identify message source. Format is [goPuff].[AgileTeam].[Repo] (gopuff.Architecture.Appinsights)
+
 ### Usage:
 ```js
 const { trackEvent, trackException } = require('appinsights-logger')

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ npm i appinsights-logger --save
 ### Environment setup
 Just set ENV variable `APPINSIGHTS_INSTRUMENTATIONKEY`
 
-Set the AI_MESSAGE_NAMESPACE ENV variable to identify message source. Format is [goPuff].[AgileTeam].[Repo] (gopuff.Architecture.Appinsights)
+Set the AI_MESSAGE_NAMESPACE ENV variable to identify message source. Format is [myCompany].[AgileTeam].[Repo] (foocompany.Architecture.Appinsights)
 
 ### Usage:
 ```js

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "appinsights-logger",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "thin, yet opinionated wrapper for applcation insights",
   "repository": "gopuff/appinsights-logger",
   "main": "dist/index.js",

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,7 +1,8 @@
 import * as appInsights from 'applicationinsights'
-import { EventTelemetry, DependencyTelemetry, ExceptionTelemetry, MetricTelemetry, RequestTelemetry, TraceTelemetry } from 'applicationinsights/out/Declarations/Contracts'
-const clientKey = (process.env.APPINSIGHTS_INSTRUMENTATIONKEY || "fake")
+import { EventTelemetry, DependencyTelemetry, ExceptionTelemetry, MetricTelemetry, RequestTelemetry, TraceTelemetry, Telemetry } from 'applicationinsights/out/Declarations/Contracts'
 import { addSamplingRulesByUrl, RulesDictonary } from './samplingRulesByUrl'
+const clientKey = (process.env.APPINSIGHTS_INSTRUMENTATIONKEY || "fake")
+const messageNamespace = (process.env.AI_MESSAGE_NAMESPACE || "gopuff.Missingnamespace")
 
 appInsights.setup(clientKey)
     .setAutoDependencyCorrelation(<boolean>(process.env.AI_AUTO_DEPENDENCY_CORRELATE === 'false' ? false : true))
@@ -23,16 +24,20 @@ ai.start()
 const debugInsightsEnabled = (process.env.DEBUG_INSIGHTS === 'true') || false
 aiClient.context.tags[aiClient.context.keys.cloudRole] = process.env.WEBSITE_SITE_NAME || 'defaultCloudRole'
 
-export function trackEvent (telemetry: EventTelemetry): void { aiClient.trackEvent(telemetry) }
-export function trackException (telemetry: ExceptionTelemetry): void { aiClient.trackException(telemetry) }
-export function trackDependency (telemetry: DependencyTelemetry): void { aiClient.trackDependency(telemetry) }
-export function trackTrace (telemetry: TraceTelemetry): void { aiClient.trackTrace(telemetry) }
-export function trackRequest (telemetry: RequestTelemetry): void { aiClient.trackRequest(telemetry) }
-export function trackMetric (telemetry: MetricTelemetry): void { aiClient.trackMetric(telemetry) }
+export function trackEvent (telemetry: EventTelemetry): void { aiClient.trackEvent(addMetadataProps(telemetry)) }
+export function trackException (telemetry: ExceptionTelemetry): void { 
+  aiClient.trackException(addMetadataProps(telemetry)) 
+}
+export function trackDependency (telemetry: DependencyTelemetry): void { 
+  aiClient.trackDependency(addMetadataProps(telemetry)) 
+}
+export function trackTrace (telemetry: TraceTelemetry): void { aiClient.trackTrace(addMetadataProps(telemetry)) }
+export function trackRequest (telemetry: RequestTelemetry): void { aiClient.trackRequest(addMetadataProps(telemetry)) }
+export function trackMetric (telemetry: MetricTelemetry): void { aiClient.trackMetric(addMetadataProps(telemetry)) }
 
 export function trackDebugEvent (telemetry: EventTelemetry): void {
   if (debugInsightsEnabled) {
-    trackEvent(telemetry)
+    trackEvent(addMetadataProps(telemetry))
   }
 }
 
@@ -56,4 +61,9 @@ export function measureDependency (marker: IMarker, data = '', success = true): 
 
 export function samplingRulesByUrl (rulesDictionary: RulesDictonary) {
   addSamplingRulesByUrl(rulesDictionary, aiClient)
+}
+
+export function addMetadataProps <T extends Telemetry>(telemetry: T) {
+  telemetry.properties = { ...telemetry.properties, namespace: messageNamespace}
+  return telemetry
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,7 +2,7 @@ import * as appInsights from 'applicationinsights'
 import { EventTelemetry, DependencyTelemetry, ExceptionTelemetry, MetricTelemetry, RequestTelemetry, TraceTelemetry, Telemetry } from 'applicationinsights/out/Declarations/Contracts'
 import { addSamplingRulesByUrl, RulesDictonary } from './samplingRulesByUrl'
 const clientKey = (process.env.APPINSIGHTS_INSTRUMENTATIONKEY || "fake")
-const messageNamespace = (process.env.AI_MESSAGE_NAMESPACE || "gopuff.Missingnamespace")
+const messageNamespace = (process.env.AI_MESSAGE_NAMESPACE || "missingnamespace")
 
 appInsights.setup(clientKey)
     .setAutoDependencyCorrelation(<boolean>(process.env.AI_AUTO_DEPENDENCY_CORRELATE === 'false' ? false : true))


### PR DESCRIPTION
Adds the namespace property to AppInsight trackFoo functions. This property is read from the ENV