### PR TITLE
require env var to enable live metrics v0.4.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "appinsights-logger",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "appinsights-logger",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "description": "thin, yet opinionated wrapper for applcation insights",
   "repository": "gopuff/appinsights-logger",
   "main": "dist/index.js",

--- a/src/index.ts
+++ b/src/index.ts
@@ -12,7 +12,7 @@ appInsights.setup(clientKey)
   .setAutoCollectDependencies(<boolean>(process.env.AI_AUTOCOLLECT_DEPENDENCIES !== 'false'))
   .setAutoCollectConsole(true)
   .setUseDiskRetryCaching(true)
-  .setSendLiveMetrics(true)
+  .setSendLiveMetrics(process.env.AI_ENABLE_LIVEMETRICS === 'true') // Default to disabled: https://github.com/microsoft/ApplicationInsights-node.js/issues/615
   .setDistributedTracingMode(appInsights.DistributedTracingModes.AI_AND_W3C)
 
 export const ai = appInsights // in case you need to override setup()


### PR DESCRIPTION
disabling live metrics by default because of: https://github.com/microsoft/ApplicationInsights-node.js/issues/615

to enable, add ENV var `AI_ENABLE_LIVEMETRICS=true`